### PR TITLE
Modularize code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,6 @@ Depends:
 Imports:
     dplyr,
     magrittr,
-    pracma,
-    reshape,
-    reshape2,
     rlang,
     tibble,
     tidyr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Depends:
     R (>= 3.2.0)
 Imports:
     dplyr,
-    forcats,
     magrittr,
     purrr,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Suggests:
     testthat
 Encoding: UTF-8
 RoxygenNote: 6.1.1
+Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,15 @@ Depends:
     R (>= 3.2.0)
 Imports:
     dplyr,
+    forcats,
     magrittr,
+    purrr,
     rlang,
+    scales,
     tibble,
     tidyr
 Suggests: 
     testthat
 Encoding: UTF-8
-RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ License: GPL-2
 Depends: 
     R (>= 3.2.0)
 Imports:
-    DataCombine,
     dplyr,
     magrittr,
     pracma,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: Amisc
 Title: Miscellaneous Utility Functions
-Version: 0.1.2.9000
-Date: 2019-01-25
+Version: 0.1.2.9001
+Date: 2019-03-27
 Authors@R: 
     c(person(given = "Aline",
              family = "Talhouk",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,5 @@
 export("%>%")
 export(describeBy)
 importFrom(magrittr,"%>%")
+importFrom(rlang,":=")
 importFrom(rlang,.data)

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -77,9 +77,17 @@ describeBy <- function(data, var.names, var.labels = var.names, by1,
     final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
   }
 
-  # Add facet total counts to row header
+  # Add facet total counts and percentages to row header
   if (ShowTotal) {
-    final[1, 2:(length(final) - 1)] <- c("N", table(facets), nrow(facets))
+    counts <- c(table(facets), nrow(facets))
+    percents <- scales::percent(
+      x = counts / nrow(facets),
+      accuracy = 10 ^ -(digits),
+      prefix = "(",
+      suffix = "%)"
+    )
+    row_header <- c("N (%)", paste(counts, percents))
+    final[1, 2:(length(final) - 1)] <- row_header
   }
   final
 }

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -49,7 +49,6 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   }
 
   # Separate selected variables into continuous and categorical
-  num.dat <- fac.dat <- NULL
   if (length(num.ind) > 0) {
     # Continuous: numeric and integer types
     num.var <- names(types)[num.ind]
@@ -66,9 +65,9 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   }
 
   # Combine summary statistics
-  if (is.null(fac.dat)) {
+  if (!exists("fac.table")) {
     final <- num.table  # Data has only continuous
-  } else if (is.null(num.dat)) {
+  } else if (!exists("num.table")) {
     final <- fac.table  # Data has only categorical
   } else {
     final <- rbind(num.table, fac.table)  # Data has both continuous/categorical

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -9,16 +9,16 @@
 #' @param var.names variable names of interest in `data`
 #' @param var.labels variable descriptions. Uses `var.names` by default.
 #' @param by1 factor to split other variables by in `data`
-#' @param dispersion measure of variability, either "sd" (default) or "se".
+#' @param by2 optional second factor to split other variables by
 #' @param ShowTotal logical; if `TRUE`, it shows the total number of each level
 #'   w/ `by1`.
-#' @param by2 optional second factor to split other variables by
-#' @param per print column ("col") or row ("row") percentages
+#' @param Missing logical; if `TRUE`, shows missing value counts, if they exist
 #' @param digits number of digits to round descriptive statistics
 #' @param p.digits number of digits to round univariable test p-value
-#' @param Missing logical; if `TRUE`, shows missing value counts, if they exist
+#' @param dispersion measure of variability, either "sd" (default) or "se".
 #' @param stats either "parametric" (default) or "non-parametric" univariable
 #'   tests are performed
+#' @param per print column ("col") or row ("row") percentages
 #' @param simulate.p.value passed to `chisq.test`. Only relevant for categorical
 #'   variables.
 #' @param B passed to `chisq.test`. Only relevant for categorical variables.
@@ -30,12 +30,12 @@
 #' mtcars$cyl <- as.factor(mtcars$cyl)
 #' mtcars$vs <- as.character(mtcars$vs)
 #' Amisc::describeBy(data = mtcars, var.names = c("vs", "hp"), by1 = "cyl",
-#' dispersion = "sd", Missing = TRUE, stats = "parametric")
-describeBy <- function(data, var.names, var.labels = var.names, by1,
-                       dispersion = c("sd", "se"), ShowTotal = TRUE, by2 = NULL,
-                       per = "col", digits = 0, p.digits = 3, Missing = TRUE,
+#' Missing = TRUE, dispersion = "sd", stats = "parametric")
+describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
+                       ShowTotal = TRUE, Missing = TRUE,
+                       digits = 0, p.digits = 3, dispersion = c("sd", "se"),
                        stats = c("parametric", "non-parametric"),
-                       simulate.p.value = FALSE, B = 2000) {
+                       per = "col", simulate.p.value = FALSE, B = 2000) {
   # Extract variables of interest
   var.dat <- data[, var.names, drop = FALSE]
   facets <- data[, c(by1, by2), drop = FALSE]
@@ -66,15 +66,15 @@ describeBy <- function(data, var.names, var.labels = var.names, by1,
   # Use uni_test_cont and/or uni_test_cat to obtain summary statistics
   if (!(is.null(fac.dat) | is.null(num.dat))) {
     # Data is a mix of continuous and categorical variables, apply uni_test_cont and uni_test_cat respectively
-    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, showMissing = Missing, stats = stats)$formatted
-    cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
+    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)$formatted
+    cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)$formatted
     final <- rbind(num.formatted, cat.formatted)
   } else if (is.null(fac.dat)) {
     # Data is only continuous, only apply uni_test_cont
-    final <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, showMissing = Missing, stats = stats)$formatted
+    final <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)$formatted
   } else if (is.null(num.dat)) {
     # Data is only categorical, only apply uni_test_cat
-    final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
+    final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)$formatted
   }
 
   # Add facet total counts and percentages to row header

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -32,10 +32,10 @@
 #' Amisc::describeBy(data = mtcars, var.names = c("vs", "hp"), by1 = "cyl",
 #' dispersion = "sd", Missing = TRUE, stats = "parametric")
 describeBy <- function(data, var.names, var.labels = var.names, by1,
-                       dispersion = "se", ShowTotal = TRUE, by2 = NULL,
+                       dispersion = c("sd", "se"), ShowTotal = TRUE, by2 = NULL,
                        per = "col", digits = 0, p.digits = 3, Missing = TRUE,
-                       stats = "parametric", simulate.p.value = FALSE,
-                       B = 2000) {
+                       stats = c("parametric", "non-parametric"),
+                       simulate.p.value = FALSE, B = 2000) {
   # Extract variables of interest
   var.dat <- data[, var.names, drop = FALSE]
   facets <- data[, c(by1, by2), drop = FALSE]
@@ -66,12 +66,12 @@ describeBy <- function(data, var.names, var.labels = var.names, by1,
   # Use uni_test_cont and/or uni_test_cat to obtain summary statistics
   if (!(is.null(fac.dat) | is.null(num.dat))) {
     # Data is a mix of continuous and categorical variables, apply uni_test_cont and uni_test_cat respectively
-    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, test.type = stats)$formatted
+    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, stats = stats)$formatted
     cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
     final <- rbind(num.formatted, cat.formatted)
   } else if (is.null(fac.dat)) {
     # Data is only continuous, only apply uni_test_cont
-    final <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, test.type = stats)$formatted
+    final <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, stats = stats)$formatted
   } else if (is.null(num.dat)) {
     # Data is only categorical, only apply uni_test_cat
     final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -9,7 +9,7 @@
 #' @param var.names variable names of interest in `data`
 #' @param var.labels variable descriptions. Uses `var.names` by default.
 #' @param by1 factor to split other variables by in `data`
-#' @param dispersion measure of variability, either "se" (default) or "sd".
+#' @param dispersion measure of variability, either "sd" (default) or "se".
 #' @param ShowTotal logical; if `TRUE`, it shows the total number of each level
 #'   w/ `by1`.
 #' @param by2 optional second factor to split other variables by
@@ -17,8 +17,8 @@
 #' @param digits number of digits to round descriptive statistics
 #' @param p.digits number of digits to round univariable test p-value
 #' @param Missing logical; if `TRUE`, shows missing value counts, if they exist
-#' @param stats either "parametric" or "non-parametric" univariable tests are
-#'   performed
+#' @param stats either "parametric" (default) or "non-parametric" univariable
+#'   tests are performed
 #' @param simulate.p.value passed to `chisq.test`. Only relevant for categorical
 #'   variables.
 #' @param B passed to `chisq.test`. Only relevant for categorical variables.

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -49,32 +49,29 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   }
 
   # Separate selected variables into continuous and categorical
-  num.var <- num.dat <- fac.var <- fac.dat <- NULL
+  num.dat <- fac.dat <- NULL
   if (length(num.ind) > 0) {
     # Continuous: numeric and integer types
     num.var <- names(types)[num.ind]
     num.label <- var.labels[num.ind]
     num.dat <- cbind(var.dat[, num.var, drop = FALSE], facets)
+    num.table <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
   }
   if (length(fac.ind) > 0) {
     # Categorical: character and factor types
     fac.var <- names(types)[fac.ind]
     fac.label <- var.labels[fac.ind]
     fac.dat <- cbind(var.dat[, fac.var, drop = FALSE], facets)
+    fac.table <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
   }
 
-  # Use uni_test_cont and/or uni_test_cat to obtain summary statistics
+  # Combine summary statistics
   if (!(is.null(fac.dat) | is.null(num.dat))) {
-    # Data is a mix of continuous and categorical variables, apply uni_test_cont and uni_test_cat respectively
-    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
-    cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
-    final <- rbind(num.formatted, cat.formatted)
+    final <- rbind(num.table, fac.table)  # Data has both continuous/categorical
   } else if (is.null(fac.dat)) {
-    # Data is only continuous, only apply uni_test_cont
-    final <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
+    final <- num.table  # Data has only continuous
   } else if (is.null(num.dat)) {
-    # Data is only categorical, only apply uni_test_cat
-    final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
+    final <- fac.table  # Data has only categorical
   }
 
   # Add facet total counts and percentages to row header

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -66,15 +66,20 @@ describeBy <- function(data, var.names, var.labels = var.names, by1,
   # Use uni_test_cont and/or uni_test_cat to obtain summary statistics
   if (!(is.null(fac.dat) | is.null(num.dat))) {
     # Data is a mix of continuous and categorical variables, apply uni_test_cont and uni_test_cat respectively
-    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, stats = stats)$formatted
+    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, showMissing = Missing, stats = stats)$formatted
     cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
     final <- rbind(num.formatted, cat.formatted)
   } else if (is.null(fac.dat)) {
     # Data is only continuous, only apply uni_test_cont
-    final <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, ShowTotal = ShowTotal, showMissing = Missing, stats = stats)$formatted
+    final <- uni_test_cont(num.dat, num.var, num.label, by1, dispersion = dispersion, digits = digits, p.digits = p.digits, showMissing = Missing, stats = stats)$formatted
   } else if (is.null(num.dat)) {
     # Data is only categorical, only apply uni_test_cat
     final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, per = per, digits = digits, p.digits = p.digits, simulate.p.value = simulate.p.value, B = B, showMissing = Missing)$formatted
+  }
+
+  # Add facet total counts to row header
+  if (ShowTotal) {
+    final[1, 2:(length(final) - 1)] <- c("N", table(facets), nrow(facets))
   }
   final
 }

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -54,14 +54,14 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
     num.var <- names(types)[num.ind]
     num.label <- var.labels[num.ind]
     num.dat <- cbind(var.dat[, num.var, drop = FALSE], facets)
-    num.table <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
+    num.table <- uni_test_cont(num.dat, num.var, num.label, by1, Missing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
   }
   if (length(fac.ind) > 0) {
     # Categorical: character and factor types
     fac.var <- names(types)[fac.ind]
     fac.label <- var.labels[fac.ind]
     fac.dat <- cbind(var.dat[, fac.var, drop = FALSE], facets)
-    fac.table <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
+    fac.table <- uni_test_cat(fac.dat, fac.var, fac.label, by1, Missing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
   }
 
   # Combine summary statistics

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -76,12 +76,7 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   # Add facet total counts and percentages to row header
   if (ShowTotal) {
     counts <- c(table(facets), nrow(facets))
-    percents <- scales::percent(
-      x = counts / nrow(facets),
-      accuracy = 10 ^ -(digits),
-      prefix = "(",
-      suffix = "%)"
-    )
+    percents <- round_percent(counts / nrow(facets), digits)
     row_header <- c("N (%)", paste(counts, percents))
     final[1, 2:(length(final) - 1)] <- row_header
   }

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -66,12 +66,12 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   }
 
   # Combine summary statistics
-  if (!(is.null(fac.dat) | is.null(num.dat))) {
-    final <- rbind(num.table, fac.table)  # Data has both continuous/categorical
-  } else if (is.null(fac.dat)) {
+  if (is.null(fac.dat)) {
     final <- num.table  # Data has only continuous
   } else if (is.null(num.dat)) {
     final <- fac.table  # Data has only categorical
+  } else {
+    final <- rbind(num.table, fac.table)  # Data has both continuous/categorical
   }
 
   # Add facet total counts and percentages to row header

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -66,15 +66,15 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   # Use uni_test_cont and/or uni_test_cat to obtain summary statistics
   if (!(is.null(fac.dat) | is.null(num.dat))) {
     # Data is a mix of continuous and categorical variables, apply uni_test_cont and uni_test_cat respectively
-    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)$formatted
-    cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)$formatted
+    num.formatted <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
+    cat.formatted <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
     final <- rbind(num.formatted, cat.formatted)
   } else if (is.null(fac.dat)) {
     # Data is only continuous, only apply uni_test_cont
-    final <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)$formatted
+    final <- uni_test_cont(num.dat, num.var, num.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, dispersion = dispersion, stats = stats)
   } else if (is.null(num.dat)) {
     # Data is only categorical, only apply uni_test_cat
-    final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)$formatted
+    final <- uni_test_cat(fac.dat, fac.var, fac.label, by1, showMissing = Missing, digits = digits, p.digits = p.digits, per = per, simulate.p.value = simulate.p.value, B = B)
   }
 
   # Add facet total counts and percentages to row header

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -5,8 +5,8 @@
 #' @param by factor variable passed as `by1` from `describeBy`
 #' @return a formatted summary of categorical variables
 #' @noRd
-uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
-                         digits = 0, p.digits = 3, showMissing,
+uni_test_cat <- function(fac.dat, fac.var, fac.label, by, showMissing,
+                         digits = 0, p.digits = 3, per = "col",
                          simulate.p.value = FALSE, B = 2000) {
   # Verify `by` is a factor and return number of levels
   ind <- fac.dat[, by]

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -9,16 +9,17 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
                          digits = 0, p.digits = 3, showMissing,
                          simulate.p.value = FALSE, B = 2000) {
   # Verify `by` is a factor and store number of distinct levels
-  if (is.factor(fac.dat[, by])) {
-    level_num <- nlevels(fac.dat[, by])
+  ind <- fac.dat[, by]
+  if (is.factor(ind)) {
+    level_num <- nlevels(ind)
   } else {
     stop("Argument 'by' must be of type factor")
   }
 
   # Obtain Summary Data
-  stats_args <- tibble::lst(ind = fac.dat[, by], level_num, digits, per,
-                            p.digits, showMissing, simulate.p.value, B)
-  row_header <- c(rep("", ncol(res) - 1), "PearsonChi_square")
+  stats_args <- tibble::lst(ind, level_num, digits, per, p.digits, showMissing,
+                            simulate.p.value, B)
+  row_header <- c(rep("", level_num + 3), "PearsonChi_square")
   formatted <- fac.dat %>%
     dplyr::transmute_at(fac.var, factor) %>%
     purrr::splice(fac.var, fac.label) %>%

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -46,9 +46,11 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
       stats::addmargins(margin = 2)
   }
   tots <- per.val %>%
-    magrittr::multiply_by(100) %>%
-    round(digits) %>%
-    paste0(stats::addmargins(count, 2), " (", ., "%)") %>%
+    as.numeric() %>%
+    scales::percent(accuracy = 10 ^ -(digits),
+                    prefix = "(",
+                    suffix = "%)") %>%
+    paste(stats::addmargins(count, 2), .) %>%
     matrix(nrow = nrow(count),
            dimnames = list(levels(x), c(levels(ind), "Total")))
 

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -5,7 +5,7 @@
 #' @param by factor variable passed as `by1` from `describeBy`
 #' @return a formatted summary of categorical variables
 #' @noRd
-uni_test_cat <- function(fac.dat, fac.var, fac.label, by, showMissing,
+uni_test_cat <- function(fac.dat, fac.var, fac.label, by, Missing,
                          digits = 0, p.digits = 3, per = "col",
                          simulate.p.value = FALSE, B = 2000) {
   # Verify `by` is a factor and return number of levels
@@ -13,7 +13,7 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, showMissing,
   level_num <- check_factor(ind)
 
   # Obtain Summary Data
-  stats_args <- tibble::lst(ind, level_num, digits, per, p.digits, showMissing,
+  stats_args <- tibble::lst(ind, level_num, digits, per, p.digits, Missing,
                             simulate.p.value, B)
   row_header <- c(rep("", level_num + 3), "PearsonChi_square")
   formatted <- fac.dat %>%
@@ -28,7 +28,7 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, showMissing,
 
 # Main functions used to obtain the marginal totals, which are the total counts of the cases over the categories of interest
 sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
-                          p.digits, showMissing, simulate.p.value, B) {
+                          p.digits, Missing, simulate.p.value, B) {
   x <- droplevels(x) # drop unused levels from a factor
   ind <- droplevels(ind)
   count <- table(x, ind, dnn = list(var, by))
@@ -48,9 +48,9 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
     matrix(nrow = nrow(count),
            dimnames = list(levels(x), c(levels(ind), "Total")))
 
-  # Missing cases will only be shown if showMissing == TRUE and there are indeed missing ones
+  # Missing cases will only be shown if Missing == TRUE and there are indeed missing ones
   na.r <- stats::addmargins(table(x, ind, useNA = "always"))[nlevels(x) + 1, -level_num - 1]
-  if (sum(na.r) != 0 && showMissing) {
+  if (sum(na.r) != 0 && Missing) {
     tots <- rbind(tots, Missing = na.r)
   }
   # re-arrange the matrix so that it will be able to rbind with continuous part

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -6,8 +6,8 @@
 #' @return a formatted summary of categorical variables
 #' @noRd
 uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
-                        digits = 0, p.digits = 3, showMissing,
-                        simulate.p.value = FALSE, B = 2000) {
+                         digits = 0, p.digits = 3, showMissing,
+                         simulate.p.value = FALSE, B = 2000) {
   # Verify `by` is a factor and store number of distinct levels
   if (is.factor(fac.dat[, by])) {
     level_num <- nlevels(fac.dat[, by])
@@ -27,34 +27,41 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
 }
 
 # Main functions used to obtain the marginal totals, which are the total counts of the cases over the categories of interest
-sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per, p.digits, showMissing, simulate.p.value, B) {
+sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
+                          p.digits, showMissing, simulate.p.value, B) {
   x <- droplevels(x) # drop unused levels from a factor
   ind <- droplevels(ind)
   count <- table(x, ind, dnn = list(var, by))
-  na.r <- stats::addmargins(table(x, ind, useNA = "always"))[nlevels(x) + 1, -level_num - 1]
   if (per == "col") {
-    per.val <- round(prop.table(stats::addmargins(count, margin = 2), margin = 2) * 100, digits)
+    per.val <- count %>%
+      stats::addmargins(margin = 2) %>%
+      prop.table(margin = 2)
   } else if (per == "row") {
-    per.val <- round(stats::addmargins(prop.table(count, margin = 1), margin = 2) * 100, digits)
+    per.val <- count %>%
+      prop.table(margin = 1) %>%
+      stats::addmargins(margin = 2)
   }
-  tots <- matrix(paste0(stats::addmargins(count, 2), " (", per.val, "%)"), byrow = FALSE, nrow = dim(count)[1]) %>%
-    magrittr::set_rownames(levels(x))
+  tots <- per.val %>%
+    magrittr::multiply_by(100) %>%
+    round(digits) %>%
+    paste0(stats::addmargins(count, 2), " (", ., "%)") %>%
+    matrix(nrow = nrow(count),
+           dimnames = list(levels(x), c(levels(ind), "Total")))
 
   # Missing cases will only be shown if showMissing == TRUE and there are indeed missing ones
-  if (sum(na.r) != 0 && showMissing == TRUE) {
+  na.r <- stats::addmargins(table(x, ind, useNA = "always"))[nlevels(x) + 1, -level_num - 1]
+  if (sum(na.r) != 0 && showMissing) {
     tots <- rbind(tots, Missing = na.r)
   }
   # re-arrange the matrix so that it will be able to rbind with continuous part
-  tot.rowname <- rownames(tots)
-  tots <- tots[, c(ncol(tots), 1:ncol(tots) - 1)]
-
-  tots <- as.data.frame(matrix(tots, ncol = nlevels(ind) + 1), row.names = tot.rowname) %>%
-    cbind(Variable = c(paste0("**", var.lab, "**"), rep("", nrow(.) - 1)), Levels = rownames(.), .) %>%
-    cbind(., AssociationTest = c(format(round(stats::chisq.test(count, simulate.p.value = simulate.p.value, B = B)$p.value, p.digits), nsmall = p.digits), rep("", nrow(.) - 1))) %>%
-    magrittr::set_rownames(NULL) %>%
-    magrittr::set_colnames(c("Variable", "Levels", "Total", levels(ind), "PValue")) %>%
-    dplyr::mutate_all(as.character)
-
-  tots <- tots[, c(1, 2, 4:(ncol(tots) - 1), 3, ncol(tots))] # re-arrange columns for the sake of output layout
+  test <- stats::chisq.test(count, simulate.p.value = simulate.p.value, B = B)$p.value
+  tots <- tots %>%
+    as.data.frame(stringsAsFactors = FALSE) %>%
+    dplyr::mutate(
+      Variable = c(paste0("**", var.lab, "**"), rep("", nrow(.) - 1)),
+      Levels = rownames(.),
+      PValue = c(format(round(test, p.digits), nsmall = p.digits), rep("", nrow(.) - 1))
+    ) %>%
+    dplyr::select(c("Variable", "Levels", levels(ind), "Total", "PValue"))
   tibble::lst(count, tots)
 }

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -16,13 +16,16 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
   }
 
   # Obtain Summary Data
-  ind <- fac.dat[, by]
-  res <- NULL
-  for (i in seq_along(fac.var)) {
-    res <- rbind(res, sum_stats_cat(factor(fac.dat[, fac.var[i]]), fac.var[i], fac.label[i], ind, level_num, digits, per, p.digits, showMissing, simulate.p.value, B))
-  }
+  stats_args <- tibble::lst(ind = fac.dat[, by], level_num, digits, per,
+                            p.digits, showMissing, simulate.p.value, B)
   row_header <- c(rep("", ncol(res) - 1), "PearsonChi_square")
-  formatted <- rbind(row_header, res)
+  formatted <- fac.dat %>%
+    dplyr::transmute_at(fac.var, factor) %>%
+    purrr::splice(fac.var, fac.label) %>%
+    purrr::pmap_dfr(~ purrr::invoke(
+      sum_stats_cat, x = ..1, var = ..2, var.lab = ..3, stats_args
+    )) %>%
+    rbind(row_header, .)
   tibble::lst(formatted)
 }
 

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -8,13 +8,9 @@
 uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
                          digits = 0, p.digits = 3, showMissing,
                          simulate.p.value = FALSE, B = 2000) {
-  # Verify `by` is a factor and store number of distinct levels
+  # Verify `by` is a factor and return number of levels
   ind <- fac.dat[, by]
-  if (is.factor(ind)) {
-    level_num <- nlevels(ind)
-  } else {
-    stop("Argument 'by' must be of type factor")
-  }
+  level_num <- check_factor(ind)
 
   # Obtain Summary Data
   stats_args <- tibble::lst(ind, level_num, digits, per, p.digits, showMissing,

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -23,7 +23,7 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, showMissing,
       sum_stats_cat, x = ..1, var = ..2, var.lab = ..3, stats_args
     )) %>%
     rbind(row_header, .)
-  tibble::lst(formatted)
+  formatted
 }
 
 # Main functions used to obtain the marginal totals, which are the total counts of the cases over the categories of interest

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -43,9 +43,7 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
   }
   tots <- per.val %>%
     as.numeric() %>%
-    scales::percent(accuracy = 10 ^ -(digits),
-                    prefix = "(",
-                    suffix = "%)") %>%
+    round_percent(digits) %>%
     paste(stats::addmargins(count, 2), .) %>%
     matrix(nrow = nrow(count),
            dimnames = list(levels(x), c(levels(ind), "Total")))
@@ -62,7 +60,7 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
     dplyr::mutate(
       Variable = c(paste0("**", var.lab, "**"), rep("", nrow(.) - 1)),
       Levels = rownames(.),
-      PValue = c(scales::pvalue(pval, accuracy = 10 ^ (-p.digits)), rep("", nrow(.) - 1))
+      PValue = c(round_pvalue(pval, p.digits), rep("", nrow(.) - 1))
     ) %>%
     dplyr::select(c("Variable", "Levels", levels(ind), "Total", "PValue"))
   tots

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -60,13 +60,13 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
     tots <- rbind(tots, Missing = na.r)
   }
   # re-arrange the matrix so that it will be able to rbind with continuous part
-  test <- stats::chisq.test(count, simulate.p.value = simulate.p.value, B = B)$p.value
+  pval <- stats::chisq.test(count, simulate.p.value = simulate.p.value, B = B)$p.value
   tots <- tots %>%
     as.data.frame(stringsAsFactors = FALSE) %>%
     dplyr::mutate(
       Variable = c(paste0("**", var.lab, "**"), rep("", nrow(.) - 1)),
       Levels = rownames(.),
-      PValue = c(format(round(test, p.digits), nsmall = p.digits), rep("", nrow(.) - 1))
+      PValue = c(scales::pvalue(pval, accuracy = 10 ^ (-p.digits)), rep("", nrow(.) - 1))
     ) %>%
     dplyr::select(c("Variable", "Levels", levels(ind), "Total", "PValue"))
   tots

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -19,11 +19,11 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, per = "col",
   ind <- fac.dat[, by]
   res <- NULL
   for (i in seq_along(fac.var)) {
-    res <- rbind(res, sum_stats_cat(factor(fac.dat[, fac.var[i]]), fac.var[i], fac.label[i], ind, level_num, digits, per, p.digits, showMissing, simulate.p.value, B)$tots)
+    res <- rbind(res, sum_stats_cat(factor(fac.dat[, fac.var[i]]), fac.var[i], fac.label[i], ind, level_num, digits, per, p.digits, showMissing, simulate.p.value, B))
   }
-  Row.Insert <- c(rep("", ncol(res) - 1), "PearsonChi_square")
-  res <- rbind(Row.Insert, res)
-  return(list(formatted = res))
+  row_header <- c(rep("", ncol(res) - 1), "PearsonChi_square")
+  formatted <- rbind(row_header, res)
+  tibble::lst(formatted)
 }
 
 # Main functions used to obtain the marginal totals, which are the total counts of the cases over the categories of interest
@@ -63,5 +63,5 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
       PValue = c(format(round(test, p.digits), nsmall = p.digits), rep("", nrow(.) - 1))
     ) %>%
     dplyr::select(c("Variable", "Levels", levels(ind), "Total", "PValue"))
-  tibble::lst(count, tots)
+  tots
 }

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -111,7 +111,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, dispersion = "sd",
     formatted <- formatted %>% dplyr::mutate_if(is.factor, as.character) # Change the factor column into character to prepare for row inserting
     Row.Insert <- c(rep("", level_num + 3), test_name)
   }
-  formatted <- DataCombine::InsertRow(formatted, NewRow = Row.Insert, RowNum = 1)
+  formatted <- rbind(Row.Insert, formatted)
   tibble::lst(raw, formatted)
 }
 

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -45,7 +45,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   raw <- rbind(group_stats, total_stats) %>%
     dplyr::mutate(
       Variable = factor(.data$Variable, levels = num.label),
-      Levels = forcats::fct_relevel(Levels, "Total", after = Inf)
+      Levels = forcats::fct_relevel(.data$Levels, "Total", after = Inf)
     ) %>%
     dplyr::arrange(.data$Variable)
 
@@ -89,7 +89,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
       Variable = ifelse(seq_along(.data$Variable) %% unique(table(.data$Variable)) == 1, paste0("**", .data$Variable, "**"), ""),
       PValue = as.vector(rbind(pvals, matrix(rep("", ifelse(showMissing, 2, 1) * length(pvals)), ncol = length(pvals))))
     ) %>%
-    dplyr::rename(Levels = Stats) %>%
+    dplyr::rename(!!"Levels" := .data$Stats) %>%
     rbind(row_header, .)
 
   # Indicate missing inputs if applicable

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -15,7 +15,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   level_num <- check_factor(ind)
 
   # Group and total continuous stats
-  df <- data.frame(num.dat[, num.var, drop = FALSE])
+  df <- num.dat[, num.var, drop = FALSE]
   group_stats <- df %>%
     purrr::map(base::by, INDICES = ind, FUN = sum_stats_cont) %>%
     purrr::imap_dfr(~ data.frame(Variable = .y, by = names(.x), purrr::invoke(rbind, .x), stringsAsFactors = FALSE))

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -103,7 +103,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
     n_missing <- length(ind) - total_count
     message(n_missing, " missing in 'by' argument ", sQuote(by), ".")
   }
-  tibble::lst(raw, formatted)
+  formatted
 }
 
 # Main function used to calculate Mean, SD, SEM, Median, IQR and Missing

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -6,9 +6,8 @@
 #' @return raw and formatted summaries of numerical variables
 #' @importFrom rlang .data :=
 #' @noRd
-uni_test_cont <- function(num.dat, num.var, num.label, by,
-                          dispersion = c("sd", "se"), digits = 0, p.digits = 3,
-                          showMissing,
+uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
+                          digits = 0, p.digits = 3, dispersion = c("sd", "se"),
                           stats = c("parametric", "non-parametric")) {
   # Verify `by` is a factor and return number of levels
   ind <- num.dat[, by]

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -84,17 +84,15 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
       dplyr::select(-"Missing", "Missing") %>%
       dplyr::mutate_at("Missing", as.character)
   }
-  # Pivot table, bold variable names, add p-values, coerce factors to character
-  # for adding row header
+  # Pivot table, bold variable names, add p-values and row header
   row_header <- c(rep("", level_num + 3), test_name)
   formatted <- formatted %>%
-    tidyr::gather(key = "Levels", , -1:-2, factor_key = TRUE) %>%
+    tidyr::gather(key = "Levels", , -1:-2) %>%
     tidyr::spread("by", "value") %>%
     dplyr::mutate(
       Variable = ifelse(seq_along(.data$Variable) %% unique(table(.data$Variable)) == 1, paste0("**", .data$Variable, "**"), ""),
-      PValue = as.vector(rbind(pvals, matrix(rep("", ifelse(showMissing, 2, 1) * length(test)), ncol = length(test))))
+      PValue = as.vector(rbind(pvals, matrix(rep("", ifelse(showMissing, 2, 1) * length(pvals)), ncol = length(pvals))))
     ) %>%
-    dplyr::mutate_if(is.factor, as.character) %>%
     rbind(row_header, .)
 
   # Indicate missing inputs if applicable

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -40,8 +40,8 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
     purrr::map_dbl(~ f(. ~ ind)$p.value) %>%
     scales::pvalue(accuracy = 10 ^ (-p.digits))
 
-  # Order num.var by num.label, we need to change num.label as a factor and
-  # manually set the level so that the order of num.label is preserved
+  # Combine group/total stats and reorder Variable by num.label
+  # Place total stats per variable after group stats
   raw <- rbind(group_stats, total_stats) %>%
     dplyr::mutate(
       Variable = factor(.data$Variable, levels = num.label),
@@ -93,10 +93,10 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
     rbind(row_header, .)
 
   # Indicate missing inputs if applicable
-  total_count <- table(ind) # counts for each level in the factor `by`
-  if (length(ind) > sum(total_count)) {
-    MissingNumber <- as.character(length(ind) - sum(total_count))
-    print(paste0(MissingNumber, " missing in the Input Argument ", by, "."))
+  total_count <- sum(table(ind))
+  if (length(ind) > total_count) {
+    n_missing <- length(ind) - total_count
+    message(n_missing, " missing in 'by' argument ", sQuote(by), ".")
   }
   tibble::lst(raw, formatted)
 }

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -14,7 +14,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
   level_num <- check_factor(ind)
 
   # Group and total continuous stats
-  df <- num.dat[, num.var, drop = FALSE]
+  df <- num.dat[, num.var, drop = FALSE] %>% dplyr::rename_all(~ num.label)
   group_stats <- df %>%
     purrr::map(base::by, INDICES = ind, FUN = sum_stats_cont) %>%
     purrr::imap_dfr(~ data.frame(

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -4,7 +4,7 @@
 #' @param num.label numerical variable descriptions
 #' @param by factor variable passed as `by1` from `describeBy`
 #' @return raw and formatted summaries of numerical variables
-#' @importFrom rlang .data
+#' @importFrom rlang .data :=
 #' @noRd
 uni_test_cont <- function(num.dat, num.var, num.label, by,
                           dispersion = c("sd", "se"), digits = 0, p.digits = 3,
@@ -47,10 +47,10 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   # manually set the level so that the order of num.label is preserved
   raw <- rbind(group_stats, total_stats) %>%
     dplyr::mutate(
-      Variable = factor(Variable, levels = num.label),
+      Variable = factor(.data$Variable, levels = num.label),
       by = forcats::fct_relevel(by, "Total", after = Inf)
     ) %>%
-    dplyr::arrange(Variable)
+    dplyr::arrange(.data$Variable)
 
   # If we cannot detect any missing element or we do not require the missing
   # parts, the "Missing" variable will be removed
@@ -86,10 +86,10 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   # Pivot table, bold variable names, add p-values, and coerce to character to
   # prepare for row inserting
   formatted <- formatted %>%
-    tidyr::gather(key = Levels, , -1:-2, factor_key = TRUE) %>%
-    tidyr::spread(by, value) %>%
+    tidyr::gather(key = "Levels", , -1:-2, factor_key = TRUE) %>%
+    tidyr::spread("by", "value") %>%
     dplyr::mutate(
-      Variable = ifelse(pracma::mod(seq_len(nrow(.)), ifelse(showMissing, 3, 2)) == 1, paste0("**", Variable, "**"), ""),
+      Variable = ifelse(pracma::mod(seq_len(nrow(.)), ifelse(showMissing, 3, 2)) == 1, paste0("**", .data$Variable, "**"), ""),
       PValue = as.vector(rbind(format(round(test, digits = p.digits), nsmall = p.digits), matrix(rep("", ifelse(showMissing, 2, 1) * length(test)), ncol = length(test))))
     ) %>%
     dplyr::mutate_if(is.factor, as.character)

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -44,7 +44,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   # Place total stats per variable after group stats
   raw <- rbind(group_stats, total_stats) %>%
     dplyr::mutate(
-      Variable = factor(.data$Variable, levels = num.label),
+      Variable = factor(.data$Variable, labels = num.label),
       Levels = forcats::fct_relevel(.data$Levels, "Total", after = Inf)
     ) %>%
     dplyr::arrange(.data$Variable)

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -7,7 +7,7 @@
 #' @importFrom rlang .data
 #' @noRd
 uni_test_cont <- function(num.dat, num.var, num.label, by, dispersion = "sd",
-                          digits = 0, p.digits = 3, ShowTotal = ShowTotal,
+                          digits = 0, p.digits = 3, ShowTotal,
                           showMissing, test.type = "parametric") {
   # Verify `by` is a factor and store number of distinct levels
   if (is.factor(num.dat[, by])) {

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -28,7 +28,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, dispersion = "sd",
     as.data.frame() %>%
     tibble::add_column(by = "Total", .before = 1) %>%
     tibble::rownames_to_column("num.var")
-  TotCount <- table(ind) # Count total number of each level in the factor column `by`
+  total_count <- table(ind) # counts for each level in the factor `by`
   ind_names <- attributes(TotCount)$dimnames$ind # a vector all level names
 
   # Choose parametric/non-parametric statistical test
@@ -85,12 +85,6 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, dispersion = "sd",
   formatted <- formatted %>%
     tidyr::gather(key = Levels, , -1:-2, factor_key = TRUE) %>%
     tidyr::spread(by, value)
-
-  # Total counts
-  total_count <- c()
-  for (i in 3:ncol(formatted)) {
-    total_count <- c(total_count, TotCount[which(colnames(formatted)[i] == ind_names)])
-  }
 
   # Add bold formatting to variable names
   formatted$Variable <- ifelse(pracma::mod(1:nrow(formatted), ifelse(showMissing, 3, 2)) == 1, paste0("**", formatted$Variable, "**"), "")

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -10,15 +10,11 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
                           dispersion = c("sd", "se"), digits = 0, p.digits = 3,
                           showMissing,
                           stats = c("parametric", "non-parametric")) {
-  # Verify `by` is a factor and store number of distinct levels
-  if (is.factor(num.dat[, by])) {
-    level_num <- nlevels(num.dat[, by])
-  } else {
-    stop("Argument 'by' must be of type factor")
-  }
+  # Verify `by` is a factor and return number of levels
+  ind <- num.dat[, by]
+  level_num <- check_factor(ind)
 
   # Group and total continuous stats
-  ind <- num.dat[, by]
   df <- data.frame(num.dat[, num.var, drop = FALSE])
   group_stats <- df %>%
     purrr::map(base::by, INDICES = ind, FUN = sum_stats_cont) %>%
@@ -97,8 +93,8 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
 
   # Indicate missing inputs if applicable
   total_count <- table(ind) # counts for each level in the factor `by`
-  if (length(num.dat[, by]) > sum(total_count)) {
-    MissingNumber <- as.character(length(num.dat[, by]) - sum(total_count))
+  if (length(ind) > sum(total_count)) {
+    MissingNumber <- as.character(length(ind) - sum(total_count))
     print(paste0(MissingNumber, " missing in the Input Argument ", by, "."))
   }
   tibble::lst(raw, formatted)

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -77,10 +77,11 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
       !!disp_name := paste0(.data$Mean, " (", .data[[disp_var]], ")"),
       `Median (IQR)` = paste0(.data$Median, " (", .data$IQR_25, " - ", .data$IQR_75, ")")
     ) %>%
-    dplyr::select(-c("Mean", "SD", "SEM", "Median", "IQR_25", "IQR_75")) %>%
-    dplyr::select(-.data$Missing, .data$Missing)
+    dplyr::select(-c("Mean", "SD", "SEM", "Median", "IQR_25", "IQR_75"))
   if ("Missing" %in% names(formatted)) {
-    formatted <- formatted %>% dplyr::mutate_at("Missing", as.character)
+    formatted <- formatted %>%
+      dplyr::select(-"Missing", "Missing") %>%
+      dplyr::mutate_at("Missing", as.character)
   }
   # Pivot table, bold variable names, add p-values, and coerce to character to
   # prepare for row inserting

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -91,7 +91,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
       PValue = pvals[match(.data$Variable, names(pvals))],
       first = !duplicated(.data$Variable),
       Variable = ifelse(.data$first, paste0("**", .data$Variable, "**"), ""),
-      PValue = ifelse(.data$first, scales::pvalue(.data$PValue, accuracy = 10 ^ (-p.digits)), "")
+      PValue = ifelse(.data$first, round_pvalue(.data$PValue, p.digits), "")
     ) %>%
     dplyr::select(-"first") %>%
     dplyr::rename(!!"Levels" := .data$Stats) %>%

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -30,7 +30,6 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
     tibble::add_column(by = "Total", .before = 1) %>%
     tibble::rownames_to_column("num.var")
   total_count <- table(ind) # counts for each level in the factor `by`
-  ind_names <- attributes(TotCount)$dimnames$ind # a vector all level names
 
   # Choose parametric/non-parametric statistical test
   switch(match.arg(stats),

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -18,7 +18,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, dispersion = "sd",
 
   # Obtain Summary Result
   ind <- num.dat[, by]
-  selected_df <- data.frame(num.dat[, num.var]) %>% magrittr::set_colnames(num.var) # Select all num.var in num.dat as a data.frame
+  selected_df <- data.frame(num.dat[, num.var, drop = FALSE]) # Select all num.var in num.dat as a data.frame
   resCont <- apply(selected_df, 2, function(x) by(x, ind, sum_stats_cont, digits = digits))
   TotCount <- table(ind) # Count total number of each level in the factor column `by`
   ind_names <- attributes(TotCount)$dimnames$ind # a vector all level names

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -6,7 +6,7 @@
 #' @return raw and formatted summaries of numerical variables
 #' @importFrom rlang .data :=
 #' @noRd
-uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
+uni_test_cont <- function(num.dat, num.var, num.label, by, Missing,
                           digits = 0, p.digits = 3, dispersion = c("sd", "se"),
                           stats = c("parametric", "non-parametric")) {
   # Verify `by` is a factor and return number of levels
@@ -53,9 +53,8 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, showMissing,
 
   # If we cannot detect any missing element or we do not require the missing
   # parts, the "Missing" variable will be removed
-  if (sum(raw[["Missing"]]) == 0 | !showMissing) {
+  if (sum(raw[["Missing"]]) == 0 | !Missing) {
     raw <- dplyr::select(raw, -.data$Missing)
-    showMissing <- FALSE # set FALSE so that missing elements will not show up
   }
 
   # Choose dispersion parameter

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -45,7 +45,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
   raw <- rbind(group_stats, total_stats) %>%
     dplyr::mutate(
       Variable = factor(.data$Variable, labels = num.label),
-      Levels = forcats::fct_relevel(.data$Levels, "Total", after = Inf)
+      Levels = factor(.data$Levels, levels = c(levels(ind), "Total"))
     ) %>%
     dplyr::arrange(.data$Variable)
 

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -89,7 +89,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by,
     tidyr::gather(key = "Levels", , -1:-2, factor_key = TRUE) %>%
     tidyr::spread("by", "value") %>%
     dplyr::mutate(
-      Variable = ifelse(pracma::mod(seq_len(nrow(.)), ifelse(showMissing, 3, 2)) == 1, paste0("**", .data$Variable, "**"), ""),
+      Variable = ifelse(seq_along(.data$Variable) %% unique(table(.data$Variable)) == 1, paste0("**", .data$Variable, "**"), ""),
       PValue = as.vector(rbind(format(round(test, digits = p.digits), nsmall = p.digits), matrix(rep("", ifelse(showMissing, 2, 1) * length(test)), ncol = length(test))))
     ) %>%
     dplyr::mutate_if(is.factor, as.character)

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,3 +9,15 @@ check_factor <- function(x) {
     stop("Splitting variable `by` does not inherit from class factor")
   }
 }
+
+#' Percent formatter with rounding
+#' @noRd
+round_percent <- function(x, digits) {
+  scales::percent(x = x, accuracy = 10 ^ -(digits), prefix = "(", suffix = "%)")
+}
+
+#' PValue formatter with rounding
+#' @noRd
+round_pvalue <- function(x, p.digits) {
+  scales::pvalue(x = x, accuracy = 10 ^ (-p.digits))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,1 +1,11 @@
 globalVariables(".")
+
+#' Check the splitting variable is a factor, and return number of levels
+#' @noRd
+check_factor <- function(x) {
+  if (inherits(x, "factor")) {
+    nlevels(x)
+  } else {
+    stop("Splitting variable `by` does not inherit from class factor")
+  }
+}

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -4,11 +4,10 @@
 \alias{describeBy}
 \title{Descriptive statistics}
 \usage{
-describeBy(data, var.names, var.labels = var.names, by1,
-  dispersion = c("sd", "se"), ShowTotal = TRUE, by2 = NULL,
-  per = "col", digits = 0, p.digits = 3, Missing = TRUE,
-  stats = c("parametric", "non-parametric"), simulate.p.value = FALSE,
-  B = 2000)
+describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
+  ShowTotal = TRUE, Missing = TRUE, digits = 0, p.digits = 3,
+  dispersion = c("sd", "se"), stats = c("parametric",
+  "non-parametric"), per = "col", simulate.p.value = FALSE, B = 2000)
 }
 \arguments{
 \item{data}{data.frame to produce descriptive statistics}
@@ -19,23 +18,23 @@ describeBy(data, var.names, var.labels = var.names, by1,
 
 \item{by1}{factor to split other variables by in \code{data}}
 
-\item{dispersion}{measure of variability, either "sd" (default) or "se".}
+\item{by2}{optional second factor to split other variables by}
 
 \item{ShowTotal}{logical; if \code{TRUE}, it shows the total number of each level
 w/ \code{by1}.}
 
-\item{by2}{optional second factor to split other variables by}
-
-\item{per}{print column ("col") or row ("row") percentages}
+\item{Missing}{logical; if \code{TRUE}, shows missing value counts, if they exist}
 
 \item{digits}{number of digits to round descriptive statistics}
 
 \item{p.digits}{number of digits to round univariable test p-value}
 
-\item{Missing}{logical; if \code{TRUE}, shows missing value counts, if they exist}
+\item{dispersion}{measure of variability, either "sd" (default) or "se".}
 
 \item{stats}{either "parametric" (default) or "non-parametric" univariable
 tests are performed}
+
+\item{per}{print column ("col") or row ("row") percentages}
 
 \item{simulate.p.value}{passed to \code{chisq.test}. Only relevant for categorical
 variables.}
@@ -57,7 +56,7 @@ factor \code{by1}.
 mtcars$cyl <- as.factor(mtcars$cyl)
 mtcars$vs <- as.character(mtcars$vs)
 Amisc::describeBy(data = mtcars, var.names = c("vs", "hp"), by1 = "cyl",
-dispersion = "sd", Missing = TRUE, stats = "parametric")
+Missing = TRUE, dispersion = "sd", stats = "parametric")
 }
 \author{
 Aline Talhouk

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -5,23 +5,24 @@
 \title{Descriptive statistics}
 \usage{
 describeBy(data, var.names, var.labels = var.names, by1,
-  dispersion = "se", ShowTotal = TRUE, by2 = NULL, per = "col",
-  digits = 0, p.digits = 3, Missing = TRUE, stats = "parametric",
-  simulate.p.value = FALSE, B = 2000)
+  dispersion = c("sd", "se"), ShowTotal = TRUE, by2 = NULL,
+  per = "col", digits = 0, p.digits = 3, Missing = TRUE,
+  stats = c("parametric", "non-parametric"), simulate.p.value = FALSE,
+  B = 2000)
 }
 \arguments{
 \item{data}{data.frame to produce descriptive statistics}
 
-\item{var.names}{variable names of interest in `data`}
+\item{var.names}{variable names of interest in \code{data}}
 
-\item{var.labels}{variable descriptions. Uses `var.names` by default.}
+\item{var.labels}{variable descriptions. Uses \code{var.names} by default.}
 
-\item{by1}{factor to split other variables by in `data`}
+\item{by1}{factor to split other variables by in \code{data}}
 
-\item{dispersion}{measure of variability, either "se" (default) or "sd".}
+\item{dispersion}{measure of variability, either "sd" (default) or "se".}
 
-\item{ShowTotal}{logical; if `TRUE`, it shows the total number of each level
-w/ `by1`.}
+\item{ShowTotal}{logical; if \code{TRUE}, it shows the total number of each level
+w/ \code{by1}.}
 
 \item{by2}{optional second factor to split other variables by}
 
@@ -31,26 +32,26 @@ w/ `by1`.}
 
 \item{p.digits}{number of digits to round univariable test p-value}
 
-\item{Missing}{logical; if `TRUE`, shows missing value counts, if they exist}
+\item{Missing}{logical; if \code{TRUE}, shows missing value counts, if they exist}
 
-\item{stats}{either "parametric" or "non-parametric" univariable tests are
-performed}
+\item{stats}{either "parametric" (default) or "non-parametric" univariable
+tests are performed}
 
-\item{simulate.p.value}{passed to `chisq.test`. Only relevant for categorical
+\item{simulate.p.value}{passed to \code{chisq.test}. Only relevant for categorical
 variables.}
 
-\item{B}{passed to `chisq.test`. Only relevant for categorical variables.}
+\item{B}{passed to \code{chisq.test}. Only relevant for categorical variables.}
 }
 \value{
 A table with descriptive statistics for continuous and categorical
-  variables and relevant univariable association tests
+variables and relevant univariable association tests
 }
 \description{
 Descriptive statistics and univariable association tests
 }
 \details{
-Takes variables from `data` and returns descriptive statistics split on
-factor `by1`.
+Takes variables from \code{data} and returns descriptive statistics split on
+factor \code{by1}.
 }
 \examples{
 mtcars$cyl <- as.factor(mtcars$cyl)

--- a/tests/testthat/test-describeBy.R
+++ b/tests/testthat/test-describeBy.R
@@ -111,6 +111,6 @@ test_that("totals can be suppressed", {
 
 test_that("missingness is reported in splitting variable", {
   mtcars$cyl[1] <- NA
-  expect_output(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "parametric"), "missing")
-  expect_output(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "non-parametric"), "missing")
+  expect_message(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "parametric"), "missing")
+  expect_message(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "non-parametric"), "missing")
 })


### PR DESCRIPTION
- row percentages for header N (%)
- add row header outside so that whether you have only categorical, only continuous, or both kinds of variables, the totals can still be shown
- use percent formatter to allow prefix and suffix parentheses
- use p-value formatter to allow inequality truncation (e.g. <0.001)
- use defaults and argument matching with `match.arg` and `switch`
- fix factor relabelling but in continuous variables stats
- fix variable description renaming