### PR TITLE
New features

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Suggests:
     testthat
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: Amisc
 Title: Miscellaneous Utility Functions
-Version: 0.1.2.9001
-Date: 2019-03-27
+Version: 0.2.0.9000
+Date: 2019-11-18
 Authors@R: 
     c(person(given = "Aline",
              family = "Talhouk",

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -17,7 +17,8 @@
 #' @param p.digits number of digits to round univariable test p-value
 #' @param dispersion measure of variability, either "sd" (default) or "se".
 #' @param stats either "parametric" (default) or "non-parametric" univariable
-#'   tests are performed
+#'   tests are performed for continuous variables. We use the parametric one-way
+#'   test or the non-parametric Kruskal-Wallis test.
 #' @param per print column ("col") or row ("row") percentages
 #' @param simulate.p.value passed to `chisq.test`. Only relevant for categorical
 #'   variables.

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -10,8 +10,8 @@
 #' @param var.labels variable descriptions. Uses `var.names` by default.
 #' @param by1 factor to split other variables by in `data`
 #' @param by2 optional second factor to split other variables by
-#' @param ShowTotal logical; if `TRUE`, it shows the total number of each level
-#'   w/ `by1`.
+#' @param total add a row showing the total counts of each `by1` level at the
+#'   `top` or `bottom` of the table. Setting `none` hides the total row.
 #' @param Missing logical; if `TRUE`, shows missing value counts, if they exist
 #' @param digits number of digits to round descriptive statistics
 #' @param p.digits number of digits to round univariable test p-value
@@ -32,7 +32,7 @@
 #' Amisc::describeBy(data = mtcars, var.names = c("vs", "hp"), by1 = "cyl",
 #' Missing = TRUE, dispersion = "sd", stats = "parametric")
 describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
-                       ShowTotal = TRUE, Missing = TRUE,
+                       total = c("top", "bottom", "none"), Missing = TRUE,
                        digits = 0, p.digits = 3, dispersion = c("sd", "se"),
                        stats = c("parametric", "non-parametric"),
                        per = "col", simulate.p.value = FALSE, B = 2000) {
@@ -73,12 +73,19 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
     final <- rbind(num.table, fac.table)  # Data has both continuous/categorical
   }
 
-  # Add facet total counts and percentages to row header
-  if (ShowTotal) {
+  # Add row for total counts and percentages
+  total <- match.arg(total)
+  if (total == "none") {
+    return(final)
+  } else {
     counts <- c(table(facets), nrow(facets))
     percents <- round_percent(counts / nrow(facets), digits)
-    row_header <- c("N (%)", paste(counts, percents))
-    final[1, 2:(length(final) - 1)] <- row_header
+    tr <- c("**Total**", "N (%)", paste(counts, percents), "")
+    if (total == "top") {
+      final <- rbind(tr, final)
+    } else if (total == "bottom") {
+      final <- rbind(final, tr)
+    }
   }
   final
 }

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -96,7 +96,11 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   # Bold the variable names
   if (bold_var) {
     dplyr::mutate(final,
-                  Variable = ifelse(Variable == "", Variable, paste0("**", Variable, "**")))
+                  Variable = ifelse(
+                    .data$Variable == "",
+                    .data$Variable,
+                    paste0("**", .data$Variable, "**")
+                  ))
   } else {
     final
   }

--- a/R/describeBy.R
+++ b/R/describeBy.R
@@ -23,6 +23,9 @@
 #' @param simulate.p.value passed to `chisq.test`. Only relevant for categorical
 #'   variables.
 #' @param B passed to `chisq.test`. Only relevant for categorical variables.
+#' @param bold_var logical; if `TRUE`, the `Variable` names are wrapped in
+#'   double asterisks. If the table is parsed by pandoc the variable names are
+#'   in bold.
 #' @return A table with descriptive statistics for continuous and categorical
 #'   variables and relevant univariable association tests
 #' @author Aline Talhouk
@@ -36,7 +39,8 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
                        total = c("top", "bottom", "none"), Missing = TRUE,
                        digits = 0, p.digits = 3, dispersion = c("sd", "se"),
                        stats = c("parametric", "non-parametric"),
-                       per = "col", simulate.p.value = FALSE, B = 2000) {
+                       per = "col", simulate.p.value = FALSE, B = 2000,
+                       bold_var = TRUE) {
   # Extract variables of interest
   var.dat <- data[, var.names, drop = FALSE]
   facets <- data[, c(by1, by2), drop = FALSE]
@@ -81,12 +85,19 @@ describeBy <- function(data, var.names, var.labels = var.names, by1, by2 = NULL,
   } else {
     counts <- c(table(facets), nrow(facets))
     percents <- round_percent(counts / nrow(facets), digits)
-    tr <- c("**Total**", "N (%)", paste(counts, percents), "")
+    tr <- c("Total", "N (%)", paste(counts, percents), "")
     if (total == "top") {
       final <- rbind(tr, final)
     } else if (total == "bottom") {
       final <- rbind(final, tr)
     }
   }
-  final
+
+  # Bold the variable names
+  if (bold_var) {
+    dplyr::mutate(final,
+                  Variable = ifelse(Variable == "", Variable, paste0("**", Variable, "**")))
+  } else {
+    final
+  }
 }

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -56,7 +56,7 @@ sum_stats_cat <- function(x, var, var.lab, ind, level_num, digits, per,
   tots <- tots %>%
     as.data.frame(stringsAsFactors = FALSE) %>%
     dplyr::mutate(
-      Variable = c(paste0("**", var.lab, "**"), rep("", nrow(.) - 1)),
+      Variable = c(var.lab, rep("", nrow(.) - 1)),
       Levels = rownames(.),
       PValue = c(round_pvalue(pval, p.digits), rep("", nrow(.) - 1))
     ) %>%

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -21,7 +21,7 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, Missing,
     purrr::pmap_dfr(~ purrr::invoke(
       sum_stats_cat, x = ..1, var = ..2, var.lab = ..3, stats_args
     ))
-  formatted
+  tibble::as_tibble(formatted)
 }
 
 # Main functions used to obtain the marginal totals, which are the total counts of the cases over the categories of interest

--- a/R/uni_test_cat.R
+++ b/R/uni_test_cat.R
@@ -15,14 +15,12 @@ uni_test_cat <- function(fac.dat, fac.var, fac.label, by, Missing,
   # Obtain Summary Data
   stats_args <- tibble::lst(ind, level_num, digits, per, p.digits, Missing,
                             simulate.p.value, B)
-  row_header <- c(rep("", level_num + 3), "PearsonChi_square")
   formatted <- fac.dat %>%
     dplyr::transmute_at(fac.var, factor) %>%
     purrr::splice(fac.var, fac.label) %>%
     purrr::pmap_dfr(~ purrr::invoke(
       sum_stats_cat, x = ..1, var = ..2, var.lab = ..3, stats_args
-    )) %>%
-    rbind(row_header, .)
+    ))
   formatted
 }
 

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -67,11 +67,12 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, Missing,
   # Formatted table with selected dispersion variable
   formatted <- raw %>%
     dplyr::mutate_if(is.numeric, round, digits = digits) %>%
-    dplyr::mutate(
+    dplyr::transmute(
+      Variable,
+      Levels,
       !!disp_name := paste0(.data$Mean, " (", .data[[disp_var]], ")"),
       `Median (IQR)` = paste0(.data$Median, " (", .data$IQR_25, " - ", .data$IQR_75, ")")
-    ) %>%
-    dplyr::select(-c("Mean", "SD", "SEM", "Median", "IQR_25", "IQR_75"))
+    )
   if ("Missing" %in% names(formatted)) {
     formatted <- formatted %>%
       dplyr::select(-"Missing", "Missing") %>%

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -74,7 +74,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, Missing,
     `non-parametric` = stats::kruskal.test
   )
   pvals <- df %>%
-    dplyr::summarize_if(is.double, ~ f(. ~ !!rlang::sym(by))$p.value) %>%
+    dplyr::summarize_if(is.numeric, ~ f(. ~ !!rlang::sym(by))$p.value) %>%
     purrr::map_chr(round_pvalue, p.digits = p.digits)
 
   # Pivot table and add p-values

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -84,7 +84,7 @@ uni_test_cont <- function(num.dat, num.var, num.label, by, Missing,
     dplyr::mutate(
       PValue = pvals[match(.data$Variable, names(pvals))],
       first = !duplicated(.data$Variable),
-      Variable = ifelse(.data$first, paste0("**", .data$Variable, "**"), ""),
+      Variable = ifelse(.data$first, as.character(.data$Variable), ""),
       PValue = ifelse(.data$first, round_pvalue(.data$PValue, p.digits), "")
     ) %>%
     dplyr::select(-"first") %>%

--- a/R/uni_test_cont.R
+++ b/R/uni_test_cont.R
@@ -113,3 +113,16 @@ sum_stats_cont <- function(x) {
     Missing = sum(is.na(x))
   )
 }
+
+# Main function used to calculate Mean, SD, SEM, Median, IQR and Missing
+sum_stats_cont2 <- function(x) {
+  data.frame(
+    Mean = mean(x, na.rm = TRUE),
+    SD = stats::sd(x, na.rm = TRUE),
+    SEM = stats::sd(x, na.rm = TRUE) / sqrt(sum(!is.na(x))),
+    Median = stats::median(x, na.rm = TRUE),
+    IQR_25 = stats::quantile(x, 0.25, na.rm = TRUE, names = FALSE),
+    IQR_75 = stats::quantile(x, 0.75, na.rm = TRUE, names = FALSE),
+    Missing = sum(is.na(x))
+  )
+}

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -4,11 +4,23 @@
 \alias{describeBy}
 \title{Descriptive statistics}
 \usage{
-describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
-  total = c("top", "bottom", "none"), Missing = TRUE, digits = 0,
-  p.digits = 3, dispersion = c("sd", "se"), stats = c("parametric",
-  "non-parametric"), per = "col", simulate.p.value = FALSE, B = 2000,
-  bold_var = TRUE)
+describeBy(
+  data,
+  var.names,
+  var.labels = var.names,
+  by1,
+  by2 = NULL,
+  total = c("top", "bottom", "none"),
+  Missing = TRUE,
+  digits = 0,
+  p.digits = 3,
+  dispersion = c("sd", "se"),
+  stats = c("parametric", "non-parametric"),
+  per = "col",
+  simulate.p.value = FALSE,
+  B = 2000,
+  bold_var = TRUE
+)
 }
 \arguments{
 \item{data}{data.frame to produce descriptive statistics}

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -7,7 +7,8 @@
 describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
   total = c("top", "bottom", "none"), Missing = TRUE, digits = 0,
   p.digits = 3, dispersion = c("sd", "se"), stats = c("parametric",
-  "non-parametric"), per = "col", simulate.p.value = FALSE, B = 2000)
+  "non-parametric"), per = "col", simulate.p.value = FALSE, B = 2000,
+  bold_var = TRUE)
 }
 \arguments{
 \item{data}{data.frame to produce descriptive statistics}
@@ -41,6 +42,10 @@ test or the non-parametric Kruskal-Wallis test.}
 variables.}
 
 \item{B}{passed to \code{chisq.test}. Only relevant for categorical variables.}
+
+\item{bold_var}{logical; if \code{TRUE}, the \code{Variable} names are wrapped in
+double asterisks. If the table is parsed by pandoc the variable names are
+in bold.}
 }
 \value{
 A table with descriptive statistics for continuous and categorical

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -5,8 +5,8 @@
 \title{Descriptive statistics}
 \usage{
 describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
-  ShowTotal = TRUE, Missing = TRUE, digits = 0, p.digits = 3,
-  dispersion = c("sd", "se"), stats = c("parametric",
+  total = c("top", "bottom", "none"), Missing = TRUE, digits = 0,
+  p.digits = 3, dispersion = c("sd", "se"), stats = c("parametric",
   "non-parametric"), per = "col", simulate.p.value = FALSE, B = 2000)
 }
 \arguments{
@@ -20,8 +20,8 @@ describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
 
 \item{by2}{optional second factor to split other variables by}
 
-\item{ShowTotal}{logical; if \code{TRUE}, it shows the total number of each level
-w/ \code{by1}.}
+\item{total}{add a row showing the total counts of each \code{by1} level at the
+\code{top} or \code{bottom} of the table. Setting \code{none} hides the total row.}
 
 \item{Missing}{logical; if \code{TRUE}, shows missing value counts, if they exist}
 

--- a/man/describeBy.Rd
+++ b/man/describeBy.Rd
@@ -32,7 +32,8 @@ describeBy(data, var.names, var.labels = var.names, by1, by2 = NULL,
 \item{dispersion}{measure of variability, either "sd" (default) or "se".}
 
 \item{stats}{either "parametric" (default) or "non-parametric" univariable
-tests are performed}
+tests are performed for continuous variables. We use the parametric one-way
+test or the non-parametric Kruskal-Wallis test.}
 
 \item{per}{print column ("col") or row ("row") percentages}
 

--- a/tests/testthat/test-describeBy.R
+++ b/tests/testthat/test-describeBy.R
@@ -23,7 +23,7 @@ test_that("multiple inputs work", {
   res <- suppressWarnings(
     describeBy(mtcars, var.names = c("vs", "hp"), by1 = "cyl")
   )
-  expect_equal(dim(res), c(6, 7))
+  expect_equal(dim(res), c(5, 7))
 })
 
 test_that("either row or column percentages can be displayed", {
@@ -103,9 +103,9 @@ test_that("dispersion can be only se or sd", {
 
 test_that("totals can be suppressed", {
   res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "parametric", total = "none")
-  expect_equal(dim(res), c(3, 7))
+  expect_equal(dim(res), c(2, 7))
   res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "non-parametric", total = "none")
-  expect_equal(dim(res), c(3, 7))
+  expect_equal(dim(res), c(2, 7))
   expect_error(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "bayesian", total = "none"))
 })
 

--- a/tests/testthat/test-describeBy.R
+++ b/tests/testthat/test-describeBy.R
@@ -102,11 +102,11 @@ test_that("dispersion can be only se or sd", {
 })
 
 test_that("totals can be suppressed", {
-  res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "parametric", ShowTotal = FALSE)
+  res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "parametric", total = "none")
   expect_equal(dim(res), c(3, 7))
-  res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "non-parametric", ShowTotal = FALSE)
+  res <- describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "non-parametric", total = "none")
   expect_equal(dim(res), c(3, 7))
-  expect_error(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "bayesian", ShowTotal = FALSE))
+  expect_error(describeBy(mtcars, var.names = "hp", by1 = "cyl", stats = "bayesian", total = "none"))
 })
 
 test_that("missingness is reported in splitting variable", {


### PR DESCRIPTION
- Place "Total" row at top/bottom of table, or hide
- Don't annotate "PValue" column with name of statistical test. Annotate in documentation
- Add parameter to toggle bolding of "Variable" names
- Refactoring of `uni_test_cont()`
  - Fixed ordering bug where multiple continuous variables were mismatched with their summary stats, #17
- Ensure output is a tibble whether categorical, continuous, or both types of variables are supplied
- Update roxygen and docs